### PR TITLE
Provide optional runtime side parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ MODULES
 
 - [power-assert-context-formatter](./packages/power-assert-context-formatter/)
 - [power-assert-context-traversal](./packages/power-assert-context-traversal/)
+- [power-assert-context-reducer-ast](./packages/power-assert-context-reducer-ast/)
 - [power-assert-renderer-base](./packages/power-assert-renderer-base/)
 - [power-assert-renderer-file](./packages/power-assert-renderer-file/)
 - [power-assert-renderer-assertion](./packages/power-assert-renderer-assertion/)
@@ -21,7 +22,7 @@ MODULES
 DESIGN DECISION
 ---------------------------------------
 
-- Unbundle ECMAScript parser from runtime side
+- Make ECMAScript parser optional at runtime
 - Make each module lightweight and small as possible
 - Avoid unnecessary dependencies
 - Make renderers less dynamic and statically analyzable. No dynamic require.

--- a/packages/power-assert-context-formatter/README.md
+++ b/packages/power-assert-context-formatter/README.md
@@ -83,6 +83,16 @@ var format = createFormatter({
 });
 ```
 
+
+#### options.reducers
+
+| type                  | default value |
+|:----------------------|:--------------|
+| `Array` of `function` | empty array   |
+
+Array of reducer function to be applied to `powerAssertContext`.
+
+
 #### options.outputOffset
 
 | type     | default value |

--- a/packages/power-assert-context-formatter/lib/create-formatter.js
+++ b/packages/power-assert-context-formatter/lib/create-formatter.js
@@ -4,19 +4,25 @@ var extend = require('xtend');
 var ContextTraversal = require('power-assert-context-traversal');
 var StringWriter = require('./string-writer');
 var defaultOptions = require('./default-options');
+var reduce = require('array-reduce');
 
 /**
+ * options.reducers [array]
  * options.renderers [array]
  * options.outputOffset [number]
  * options.lineSeparator [string]
  */
 module.exports = function createFormatter (options) {
     var formatterConfig = extend(defaultOptions(), options);
+    var reducers = formatterConfig.reducers || [];
     var rendererConfigs = formatterConfig.renderers;
     var len = rendererConfigs.length;
 
     return function (powerAssertContext) {
-        var traversal = new ContextTraversal(powerAssertContext);
+        var context = reduce(reducers, function (prevContext, reducer) {
+            return reducer(prevContext);
+        }, powerAssertContext);
+        var traversal = new ContextTraversal(context);
         var writer = new StringWriter(formatterConfig);
         for (var i = 0; i < len; i += 1) {
             var RendererClass;

--- a/packages/power-assert-context-formatter/lib/default-options.js
+++ b/packages/power-assert-context-formatter/lib/default-options.js
@@ -2,6 +2,8 @@
 
 module.exports = function defaultOptions () {
     return {
+        reducers: [
+        ],
         outputOffset: 2,
         lineSeparator: '\n'
     };

--- a/packages/power-assert-context-formatter/package.json
+++ b/packages/power-assert-context-formatter/package.json
@@ -11,11 +11,13 @@
     "url": "https://github.com/twada/power-assert-runtime/issues"
   },
   "dependencies": {
+    "array-reduce": "0.0.0",
     "power-assert-context-traversal": "^0.1.0",
     "xtend": "^4.0.1"
   },
   "devDependencies": {
     "mocha": "^2.4.5",
+    "power-assert-context-reducer-ast": "^0.1.0",
     "power-assert-renderer-assertion": "^0.1.0",
     "power-assert-renderer-diagram": "^0.1.0"
   },

--- a/packages/power-assert-context-formatter/test/test.js
+++ b/packages/power-assert-context-formatter/test/test.js
@@ -8,6 +8,7 @@ var baseAssert = require('assert');
 var assert = require('../../../test_helper/empowered-assert');
 var transpile = require('../../../test_helper/transpile');
 var extend = require('xtend');
+var appendAst = require('power-assert-context-reducer-ast');
 
 
 describe('power-assert-context-formatter : renderers option', function () {
@@ -59,6 +60,38 @@ describe('power-assert-context-formatter : renderers option', function () {
             ].join('\n'));
         }
     });
+});
+
+
+describe('power-assert-context-formatter : reducers option', function () {
+
+    it('append ast reducer', function () {
+        var format = createFormatter({
+            reducers: [
+                appendAst
+            ],
+            renderers: [
+                AssertionRenderer,
+                DiagramRenderer
+            ]
+        });
+        try {
+            var foo = { name: 'foo', items: ['one', 'two'] };
+            var bar = { name: 'bar', items: ['toto', 'tata'] };
+            eval(transpile('assert.deepEqual(foo, bar)', false));
+        } catch (e) {
+            var result = format(e.powerAssertContext);
+            baseAssert.equal(result, [
+                '  ',
+                '  assert.deepEqual(foo, bar)',
+                '                   |    |   ',
+                '                   |    Object{name:"bar",items:#Array#}',
+                '                   Object{name:"foo",items:#Array#}',
+                '  '
+            ].join('\n'));
+        }
+    });
+
 });
 
 

--- a/packages/power-assert-context-reducer-ast/README.md
+++ b/packages/power-assert-context-reducer-ast/README.md
@@ -1,0 +1,107 @@
+[![power-assert][power-assert-banner]][power-assert-url]
+
+[![Build Status][travis-image]][travis-url]
+
+
+`powerAssertContext` reducer function to parse assertion expression at runtime.
+
+Use this function when transpiler side does not add `ast`, `tokens` and `visitorKeys` at compile time.
+
+
+API
+---------------------------------------
+
+### var appendAst = require('power-assert-context-reducer-ast');
+### var appendedContext = appendAst(powerAssertContext);
+
+Given `powerAssertContext` object, having structure below but does not have `ast`, `tokens` and `visitorKeys`, append them to output context.
+
+
+input:
+```js
+{
+    source: {
+        content: 'assert(foo === bar)',
+        filepath: 'test/some_test.js',
+        line: 1
+    },
+    args: [
+        {
+            value: false,
+            events: [
+                {
+                    value: "FOO",
+                    espath: "arguments/0/left"
+                },
+                {
+                    value: "BAR",
+                    espath: "arguments/0/right"
+                },
+                {
+                    value: false,
+                    espath: "arguments/0"
+                }
+            ]
+        }
+    ]
+}
+```
+
+output:
+
+```js
+{
+    source: {
+        content: 'assert(foo === bar)',
+        filepath: 'test/some_test.js',
+        line: 1,
+        ast: '### JSON representation of AST nodes ###',
+        tokens: '### JSON representation of AST tokens ###',
+        visitorKeys: '### JSON representation of AST visitor keys ###'
+    },
+    args: [
+        {
+            value: false,
+            events: [
+                {
+                    value: "FOO",
+                    espath: "arguments/0/left"
+                },
+                {
+                    value: "BAR",
+                    espath: "arguments/0/right"
+                },
+                {
+                    value: false,
+                    espath: "arguments/0"
+                }
+            ]
+        }
+    ]
+}
+```
+
+
+INSTALL
+---------------------------------------
+
+```sh
+$ npm install --save-dev power-assert-context-reducer-ast
+```
+
+
+AUTHOR
+---------------------------------------
+* [Takuto Wada](https://github.com/twada)
+
+
+LICENSE
+---------------------------------------
+Licensed under the [MIT](https://github.com/twada/power-assert-runtime/blob/master/LICENSE) license.
+
+
+[power-assert-url]: https://github.com/power-assert-js/power-assert
+[power-assert-banner]: https://raw.githubusercontent.com/power-assert-js/power-assert-js-logo/master/banner/banner-official-fullcolor.png
+
+[travis-url]: https://travis-ci.org/twada/power-assert-runtime
+[travis-image]: https://secure.travis-ci.org/twada/power-assert-runtime.svg?branch=master

--- a/packages/power-assert-context-reducer-ast/index.js
+++ b/packages/power-assert-context-reducer-ast/index.js
@@ -10,9 +10,9 @@ module.exports = function (powerAssertContext) {
     var source = powerAssertContext.source;
     var astAndTokens = parse(source);
     var newSource = assign({}, source, {
-        ast: JSON.stringify(purifyAst(astAndTokens.expression)),
-        tokens: JSON.stringify(astAndTokens.tokens),
-        visitorKeys: JSON.stringify(estraverse.VisitorKeys)
+        ast: purifyAst(astAndTokens.expression),
+        tokens: astAndTokens.tokens,
+        visitorKeys: estraverse.VisitorKeys
     });
     return assign({}, powerAssertContext, { source: newSource });
 };
@@ -81,23 +81,26 @@ function wrappedInAsync (jsCode) {
 }
 
 function offsetAndSlimDownTokens (tokens) {
-    var i, token, result = [];
+    var i, token, newToken, result = [];
     var columnOffset;
     for(i = 0; i < tokens.length; i += 1) {
         token = tokens[i];
         if (i === 0) {
             columnOffset = token.loc.start.column;
         }
-        result.push({
+        newToken = {
             type: {
                 label: token.type.label
-            },
-            value: token.value,
-            range: [
-                token.loc.start.column - columnOffset,
-                token.loc.end.column - columnOffset
-            ]
-        });
+            }
+        };
+        if (typeof token.value !== 'undefined') {
+            newToken.value = token.value;
+        }
+        newToken.range = [
+            token.loc.start.column - columnOffset,
+            token.loc.end.column - columnOffset
+        ];
+        result.push(newToken);
     }
     return result;
 }

--- a/packages/power-assert-context-reducer-ast/index.js
+++ b/packages/power-assert-context-reducer-ast/index.js
@@ -1,0 +1,103 @@
+'use strict';
+
+var parser = require('acorn');
+require('acorn-es7-plugin')(parser);
+var estraverse = require('estraverse');
+var purifyAst = require('espurify').customize({extra: ['range']});
+var assign = require('object-assign');
+
+module.exports = function (powerAssertContext) {
+    var source = powerAssertContext.source;
+    var astAndTokens = parse(source);
+    var newSource = assign({}, source, {
+        ast: JSON.stringify(purifyAst(astAndTokens.expression)),
+        tokens: JSON.stringify(astAndTokens.tokens),
+        visitorKeys: JSON.stringify(estraverse.VisitorKeys)
+    });
+    return assign({}, powerAssertContext, { source: newSource });
+};
+
+function parserOptions(tokens) {
+    return {
+        sourceType: 'module',
+        ecmaVersion: 7,
+        locations: true,
+        ranges: false,
+        onToken: tokens,
+        plugins: {asyncawait: true}
+    };
+}
+
+function parse (source) {
+    var code = source.content;
+    var ast, tokens;
+
+    function doParse(wrapper) {
+        var content = wrapper ? wrapper(code) : code;
+        var tokenBag = [];
+        ast = parser.parse(content, parserOptions(tokenBag));
+        if (wrapper) {
+            ast = ast.body[0].body;
+            tokens = tokenBag.slice(6, -2);
+        } else {
+            tokens = tokenBag.slice(0, -1);
+        }
+    }
+
+    if (source.async) {
+        doParse(wrappedInAsync);
+    } else if (source.generator) {
+        doParse(wrappedInGenerator);
+    } else {
+        doParse();
+    }
+
+    var exp = ast.body[0].expression;
+    var columnOffset = exp.loc.start.column;
+    var offsetTree = estraverse.replace(exp, {
+        keys: estraverse.VisitorKeys,
+        enter: function (eachNode) {
+            eachNode.range = [
+                eachNode.loc.start.column - columnOffset,
+                eachNode.loc.end.column - columnOffset
+            ];
+            delete eachNode.loc;
+            return eachNode;
+        }
+    });
+
+    return {
+        tokens: offsetAndSlimDownTokens(tokens),
+        expression: offsetTree
+    };
+}
+
+function wrappedInGenerator (jsCode) {
+    return 'function *wrapper() { ' + jsCode + ' }';
+}
+
+function wrappedInAsync (jsCode) {
+    return 'async function wrapper() { ' + jsCode + ' }';
+}
+
+function offsetAndSlimDownTokens (tokens) {
+    var i, token, result = [];
+    var columnOffset;
+    for(i = 0; i < tokens.length; i += 1) {
+        token = tokens[i];
+        if (i === 0) {
+            columnOffset = token.loc.start.column;
+        }
+        result.push({
+            type: {
+                label: token.type.label
+            },
+            value: token.value,
+            range: [
+                token.loc.start.column - columnOffset,
+                token.loc.end.column - columnOffset
+            ]
+        });
+    }
+    return result;
+}

--- a/packages/power-assert-context-reducer-ast/package.json
+++ b/packages/power-assert-context-reducer-ast/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "power-assert-context-reducer-ast",
+  "description": "append AST into power-assert context",
+  "version": "0.1.0",
+  "author": {
+    "name": "Takuto Wada",
+    "email": "takuto.wada@gmail.com",
+    "url": "https://github.com/twada"
+  },
+  "bugs": {
+    "url": "https://github.com/twada/power-assert-runtime/issues"
+  },
+  "dependencies": {
+    "estraverse": "^4.2.0",
+    "object-assign": "^4.1.0"
+  },
+  "devDependencies": {
+    "acorn": "^3.1.0",
+    "acorn-es7-plugin": "^1.0.12",
+    "mocha": "^2.4.5"
+  },
+  "files": [
+    "README.md",
+    "index.js",
+    "lib"
+  ],
+  "homepage": "https://github.com/twada/power-assert-runtime",
+  "keywords": [
+    "power-assert"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/twada/power-assert-runtime.git"
+  },
+  "scripts": {
+    "test": "mocha"
+  }
+}

--- a/packages/power-assert-context-reducer-ast/package.json
+++ b/packages/power-assert-context-reducer-ast/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/twada/power-assert-runtime/issues"
   },
   "dependencies": {
+    "espurify": "^1.5.1",
     "estraverse": "^4.2.0",
     "object-assign": "^4.1.0"
   },

--- a/packages/power-assert-context-reducer-ast/test/test.js
+++ b/packages/power-assert-context-reducer-ast/test/test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+var assert = require('assert');
+var estraverse = require('estraverse');
+delete require.cache[require.resolve('..')];
+var filter = require('..');
+
+describe('power-assert-context-reducer-ast', function () {
+
+    it('add parsed AST, tokens and visitor keys into output', function () {
+        var input = {
+            source: {
+                content: 'assert(foo === bar)',
+                filepath: 'test/some_test.js',
+                line: 1
+            },
+            args: [
+                {
+                    value: false,
+                    events: [
+                        {
+                            value: "FOO",
+                            espath: "arguments/0/left"
+                        },
+                        {
+                            value: "BAR",
+                            espath: "arguments/0/right"
+                        },
+                        {
+                            value: false,
+                            espath: "arguments/0"
+                        }
+                    ]
+                }
+            ]
+        };
+        var inputClone = JSON.parse(JSON.stringify(input));
+        var originalSource = input.source;
+
+        var actual = filter(input);
+        assert(actual !== input);
+        assert(originalSource === input.source);
+        assert.notDeepEqual(actual, input);
+        assert.deepEqual(input, inputClone);
+
+        var expected = {
+            source: {
+                content: 'assert(foo === bar)',
+                filepath: 'test/some_test.js',
+                line: 1,
+                ast: '{"type":"CallExpression","callee":{"type":"Identifier","name":"assert","range":[0,6]},"arguments":[{"type":"BinaryExpression","operator":"===","left":{"type":"Identifier","name":"foo","range":[7,10]},"right":{"type":"Identifier","name":"bar","range":[15,18]},"range":[7,18]}],"range":[0,19]}',
+                tokens: '[{"type":{"label":"name"},"value":"assert","range":[0,6]},{"type":{"label":"("},"range":[6,7]},{"type":{"label":"name"},"value":"foo","range":[7,10]},{"type":{"label":"==/!="},"value":"===","range":[11,14]},{"type":{"label":"name"},"value":"bar","range":[15,18]},{"type":{"label":")"},"range":[18,19]}]',
+                visitorKeys: JSON.stringify(estraverse.VisitorKeys)
+            },
+            args: [
+                {
+                    value: false,
+                    events: [
+                        {
+                            value: "FOO",
+                            espath: "arguments/0/left"
+                        },
+                        {
+                            value: "BAR",
+                            espath: "arguments/0/right"
+                        },
+                        {
+                            value: false,
+                            espath: "arguments/0"
+                        }
+                    ]
+                }
+            ]
+        };
+        assert.deepEqual(actual, expected);
+    });
+});

--- a/packages/power-assert-context-reducer-ast/test/test.js
+++ b/packages/power-assert-context-reducer-ast/test/test.js
@@ -3,12 +3,11 @@
 var assert = require('assert');
 var estraverse = require('estraverse');
 delete require.cache[require.resolve('..')];
-var filter = require('..');
+var reduce = require('..');
 
 describe('power-assert-context-reducer-ast', function () {
-
-    it('add parsed AST, tokens and visitor keys into output', function () {
-        var input = {
+    beforeEach(function () {
+        this.input = {
             source: {
                 content: 'assert(foo === bar)',
                 filepath: 'test/some_test.js',
@@ -34,15 +33,32 @@ describe('power-assert-context-reducer-ast', function () {
                 }
             ]
         };
-        var inputClone = JSON.parse(JSON.stringify(input));
-        var originalSource = input.source;
+    });
 
-        var actual = filter(input);
-        assert(actual !== input);
-        assert(originalSource === input.source);
-        assert.notDeepEqual(actual, input);
-        assert.deepEqual(input, inputClone);
+    it('new context is not deeply equal to original', function () {
+        var actual = reduce(this.input);
+        assert.notDeepEqual(actual, this.input);
+    });
 
+    it('original context should not be changed', function () {
+        var inputClone = JSON.parse(JSON.stringify(this.input));
+        reduce(this.input);
+        assert.deepEqual(this.input, inputClone);
+    });
+
+    it('returns new context', function () {
+        var actual = reduce(this.input);
+        assert(actual !== this.input);
+    });
+
+    it('original context reference should not be changed', function () {
+        var originalSource = this.input.source;
+        reduce(this.input);
+        assert(originalSource === this.input.source);
+    });
+
+    it('add parsed AST, tokens and visitor keys into output', function () {
+        var actual = reduce(this.input);
         var expected = {
             source: {
                 content: 'assert(foo === bar)',

--- a/packages/power-assert-context-reducer-ast/test/test.js
+++ b/packages/power-assert-context-reducer-ast/test/test.js
@@ -64,9 +64,9 @@ describe('power-assert-context-reducer-ast', function () {
                 content: 'assert(foo === bar)',
                 filepath: 'test/some_test.js',
                 line: 1,
-                ast: '{"type":"CallExpression","callee":{"type":"Identifier","name":"assert","range":[0,6]},"arguments":[{"type":"BinaryExpression","operator":"===","left":{"type":"Identifier","name":"foo","range":[7,10]},"right":{"type":"Identifier","name":"bar","range":[15,18]},"range":[7,18]}],"range":[0,19]}',
-                tokens: '[{"type":{"label":"name"},"value":"assert","range":[0,6]},{"type":{"label":"("},"range":[6,7]},{"type":{"label":"name"},"value":"foo","range":[7,10]},{"type":{"label":"==/!="},"value":"===","range":[11,14]},{"type":{"label":"name"},"value":"bar","range":[15,18]},{"type":{"label":")"},"range":[18,19]}]',
-                visitorKeys: JSON.stringify(estraverse.VisitorKeys)
+                ast: JSON.parse('{"type":"CallExpression","callee":{"type":"Identifier","name":"assert","range":[0,6]},"arguments":[{"type":"BinaryExpression","operator":"===","left":{"type":"Identifier","name":"foo","range":[7,10]},"right":{"type":"Identifier","name":"bar","range":[15,18]},"range":[7,18]}],"range":[0,19]}'),
+                tokens: JSON.parse('[{"type":{"label":"name"},"value":"assert","range":[0,6]},{"type":{"label":"("},"range":[6,7]},{"type":{"label":"name"},"value":"foo","range":[7,10]},{"type":{"label":"==/!="},"value":"===","range":[11,14]},{"type":{"label":"name"},"value":"bar","range":[15,18]},{"type":{"label":")"},"range":[18,19]}]'),
+                visitorKeys: estraverse.VisitorKeys
             },
             args: [
                 {

--- a/packages/power-assert-context-traversal/package.json
+++ b/packages/power-assert-context-traversal/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "array-foreach": "^1.0.1",
     "array-reduce": "0.0.0",
-    "estraverse": "^4.1.0"
+    "estraverse": "^4.1.0",
+    "object-assign": "^4.1.0"
   },
   "devDependencies": {
     "babel-types": "^6.1.0",

--- a/test_helper/transpile.js
+++ b/test_helper/transpile.js
@@ -3,11 +3,13 @@
 var babel = require('babel-core');
 var createEspowerPlugin = require('babel-plugin-espower/create');
 
-module.exports = function transpile (code) {
+module.exports = function transpile (code, embedAst) {
+    embedAst = (embedAst !== undefined) ? embedAst : true;
     return babel.transform(code, {
         filename: '/absolute/path/to/project/test/some_test.js',
         plugins: [
             createEspowerPlugin(babel, {
+                embedAst: embedAst,
                 sourceRoot: '/absolute/path/to/project'
             })
         ]


### PR DESCRIPTION
Provides optional runtime side parser using reducer chain.

Parses assertion expression at runtime. Makes compiler side small and fast, like current power-assert architecture.

- [x] acorn-based runtime side parser
- [x] introduce reducer architecture into formatter
- [x] README
- [x] avoid unnecessary `JSON.stringify`
