### PR TITLE
Change default output depth to 2

### DIFF
--- a/packages/power-assert-context-formatter/test/test.js
+++ b/packages/power-assert-context-formatter/test/test.js
@@ -30,8 +30,8 @@ describe('power-assert-context-formatter : renderers option', function () {
                 '  ',
                 '  assert.deepEqual(foo, bar)',
                 '                   |    |   ',
-                '                   |    Object{name:"bar",items:#Array#}',
-                '                   Object{name:"foo",items:#Array#}',
+                '                   |    Object{name:"bar",items:["toto","tata"]}',
+                '                   Object{name:"foo",items:["one","two"]}',
                 '  '
             ].join('\n'));
         }
@@ -85,8 +85,8 @@ describe('power-assert-context-formatter : reducers option', function () {
                 '  ',
                 '  assert.deepEqual(foo, bar)',
                 '                   |    |   ',
-                '                   |    Object{name:"bar",items:#Array#}',
-                '                   Object{name:"foo",items:#Array#}',
+                '                   |    Object{name:"bar",items:["toto","tata"]}',
+                '                   Object{name:"foo",items:["one","two"]}',
                 '  '
             ].join('\n'));
         }

--- a/packages/power-assert-renderer-comparison/README.md
+++ b/packages/power-assert-renderer-comparison/README.md
@@ -33,7 +33,7 @@ Function to stringify any target value.
 
 | type     | default value |
 |:---------|:--------------|
-| `number` | `1`           |
+| `number` | `2`           |
 
 Depth of object traversal. If object depth is greater than `maxDepth`, compound object (IOW, `Array` or `object`) will be pruned with `#` like `["foo",#Array#,#Object#]`.
 

--- a/packages/power-assert-renderer-comparison/lib/default-options.js
+++ b/packages/power-assert-renderer-comparison/lib/default-options.js
@@ -3,7 +3,7 @@
 module.exports = function defaultOptions () {
     return {
         lineDiffThreshold: 5,
-        maxDepth: 1,
+        maxDepth: 2,
         indent: null,
         outputOffset: 2,
         anonymous: 'Object',

--- a/packages/power-assert-renderer-diagram/README.md
+++ b/packages/power-assert-renderer-diagram/README.md
@@ -33,7 +33,7 @@ Function to stringify any target value.
 
 | type     | default value |
 |:---------|:--------------|
-| `number` | `1`           |
+| `number` | `2`           |
 
 Depth of object traversal. If object depth is greater than `maxDepth`, compound object (IOW, `Array` or `object`) will be pruned with `#` like `["foo",#Array#,#Object#]`.
 

--- a/packages/power-assert-renderer-diagram/lib/default-options.js
+++ b/packages/power-assert-renderer-diagram/lib/default-options.js
@@ -3,7 +3,7 @@
 module.exports = function defaultOptions () {
     return {
         ambiguousEastAsianCharWidth: 2,
-        maxDepth: 1,
+        maxDepth: 2,
         indent: null,
         outputOffset: 2,
         anonymous: 'Object',

--- a/packages/power-assert-renderer-diagram/test/test.js
+++ b/packages/power-assert-renderer-diagram/test/test.js
@@ -121,7 +121,7 @@ describe('DiagramRenderer', function () {
             '       |      |   |   |         ',
             '       |      |   |   false     ',
             '       |      |   Object{baz:false}',
-            '       true   Object{bar:#Object#}',
+            '       true   Object{bar:Object{baz:false}}',
         ]);
     });
 
@@ -157,7 +157,7 @@ describe('DiagramRenderer', function () {
             '       |  |   |   ',
             '       |  |   false',
             '       |  Object{bar:false}',
-            '       Object{foo:#Object#}'
+            '       Object{foo:Object{bar:false}}'
         ]);
         
         test('undefined property', function (transpiledCode) {

--- a/packages/power-assert-renderer-succinct/README.md
+++ b/packages/power-assert-renderer-succinct/README.md
@@ -31,7 +31,7 @@ Function to stringify any target value.
 
 | type     | default value |
 |:---------|:--------------|
-| `number` | `1`           |
+| `number` | `2`           |
 
 Depth of object traversal. If object depth is greater than `maxDepth`, compound object (IOW, `Array` or `object`) will be pruned with `#` like `["foo",#Array#,#Object#]`.
 


### PR DESCRIPTION
Since current default depth (= `1`) is too shallow sometimes.