### PR TITLE
Use diff-match-patch instead of googlediff

### DIFF
--- a/packages/power-assert-renderer-comparison/lib/udiff.js
+++ b/packages/power-assert-renderer-comparison/lib/udiff.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var DiffMatchPatch = require('googlediff');
+var DiffMatchPatch = require('diff-match-patch');
 var dmp = new DiffMatchPatch();
 
 function udiff (config) {

--- a/packages/power-assert-renderer-comparison/package.json
+++ b/packages/power-assert-renderer-comparison/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "core-js": "^2.0.0",
-    "googlediff": "^0.1.0",
+    "diff-match-patch": "^1.0.0",
     "power-assert-renderer-base": "^1.0.0",
     "stringifier": "^1.3.0",
     "type-name": "^2.0.1"


### PR DESCRIPTION
Use [diff-match-patch](https://www.npmjs.com/package/diff-match-patch) instead of [googlediff](https://www.npmjs.com/package/googlediff) since googlediff manipulates `this` directly.

refs #12 