### PR TITLE
Extract power-assert-util-string-width module out

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ MODULES
 - [power-assert-renderer-comparison](./packages/power-assert-renderer-comparison/)
 - [power-assert-renderer-diagram](./packages/power-assert-renderer-diagram/)
 - [power-assert-renderer-succinct](./packages/power-assert-renderer-succinct/)
+- [power-assert-util-string-width](./packages/power-assert-util-string-width/)
 
 
 DESIGN DECISION

--- a/packages/power-assert-renderer-diagram/README.md
+++ b/packages/power-assert-renderer-diagram/README.md
@@ -71,7 +71,7 @@ Name to show when target object is detected as circular structure.
 
 | type       | default value |
 |:-----------|:--------------|
-| `function` | [string-width.js](https://github.com/twada/power-assert-runtime/blob/master/packages/power-assert-renderer-diagram/lib/string-width.js) |
+| `function` | [power-assert-util-string-width](https://github.com/twada/power-assert-runtime/blob/master/packages/power-assert-util-string-width) |
 
 Function to calculate width of string.
 

--- a/packages/power-assert-renderer-diagram/index.js
+++ b/packages/power-assert-renderer-diagram/index.js
@@ -4,7 +4,7 @@ var BaseRenderer = require('power-assert-renderer-base');
 var inherits = require('util').inherits;
 var forEach = require('core-js/library/fn/array/for-each');
 var stringifier = require('stringifier');
-var stringWidth = require('./lib/string-width');
+var stringWidth = require('power-assert-util-string-width');
 var assign = require('core-js/library/fn/object/assign');
 var defaultOptions = require('./lib/default-options');
 
@@ -30,7 +30,7 @@ function DiagramRenderer (config) {
     if (typeof this.config.widthOf === 'function') {
         this.widthOf = this.config.widthOf;
     } else {
-        this.widthOf = stringWidth(this.config);
+        this.widthOf = (this.config.ambiguousEastAsianCharWidth === 1) ? stringWidth.narrow : stringWidth;
     }
     this.initialVertivalBarLength = 1;
 }
@@ -124,5 +124,4 @@ function rightToLeft (a, b) {
     return b.leftIndex - a.leftIndex;
 }
 
-DiagramRenderer.stringWidth = stringWidth;
 module.exports = DiagramRenderer;

--- a/packages/power-assert-renderer-succinct/README.md
+++ b/packages/power-assert-renderer-succinct/README.md
@@ -69,7 +69,7 @@ Name to show when target object is detected as circular structure.
 
 | type       | default value |
 |:-----------|:--------------|
-| `function` | [string-width.js](https://github.com/twada/power-assert-runtime/blob/master/packages/power-assert-renderer-diagram/lib/string-width.js) |
+| `function` | [power-assert-util-string-width](https://github.com/twada/power-assert-runtime/blob/master/packages/power-assert-util-string-width) |
 
 Function to calculate width of string.
 

--- a/packages/power-assert-util-string-width/README.md
+++ b/packages/power-assert-util-string-width/README.md
@@ -16,9 +16,9 @@ var stringWidth = require('power-assert-util-string-width');
 stringWidth('abcde'); //=> 5
 stringWidth('あいうえお'); //=> 10
 stringWidth('ｱｲｳｴｵ'); //=> 5
-stringWidth('※ただしイケメンに限る');  //=> 22
+stringWidth('※脚注');  //=> 6
 // stringWidth.narrow treats ambiguous-width characters as narrow (= `1`)
-stringWidth.narrow('※ただしイケメンに限る');  //=> 21
+stringWidth.narrow('※脚注');  //=> 5
 ```
 
 

--- a/packages/power-assert-util-string-width/README.md
+++ b/packages/power-assert-util-string-width/README.md
@@ -1,0 +1,53 @@
+[![power-assert][power-assert-banner]][power-assert-url]
+
+[![Build Status][travis-image]][travis-url]
+[![NPM version][npm-image]][npm-url]
+[![License][license-image]][license-url]
+
+
+Calculates width of given string. Treat ambiguous-width characters as fullwidth (= `2`) by default.
+
+
+USAGE
+---------------------------------------
+
+```js
+var stringWidth = require('power-assert-util-string-width');
+stringWidth('abcde'); //=> 5
+stringWidth('あいうえお'); //=> 10
+stringWidth('ｱｲｳｴｵ'); //=> 5
+stringWidth('※ただしイケメンに限る');  //=> 22
+// stringWidth.narrow treats ambiguous-width characters as narrow (= `1`)
+stringWidth.narrow('※ただしイケメンに限る');  //=> 21
+```
+
+
+INSTALL
+---------------------------------------
+
+```sh
+$ npm install --save-dev power-assert-util-string-width
+```
+
+
+AUTHOR
+---------------------------------------
+* [Takuto Wada](https://github.com/twada)
+
+
+LICENSE
+---------------------------------------
+Licensed under the [MIT](https://github.com/twada/power-assert-runtime/blob/master/LICENSE) license.
+
+
+[power-assert-url]: https://github.com/power-assert-js/power-assert
+[power-assert-banner]: https://raw.githubusercontent.com/power-assert-js/power-assert-js-logo/master/banner/banner-official-fullcolor.png
+
+[travis-url]: https://travis-ci.org/twada/power-assert-runtime
+[travis-image]: https://secure.travis-ci.org/twada/power-assert-runtime.svg?branch=master
+
+[npm-url]: https://npmjs.org/package/power-assert-util-string-width
+[npm-image]: https://badge.fury.io/js/power-assert-util-string-width.svg
+
+[license-url]: http://twada.mit-license.org/
+[license-image]: https://img.shields.io/badge/license-MIT-brightgreen.svg

--- a/packages/power-assert-util-string-width/index.js
+++ b/packages/power-assert-util-string-width/index.js
@@ -2,8 +2,7 @@
 
 var eaw = require('eastasianwidth');
 
-function stringWidth (config) {
-    var ambiguousCharWidth = (config && config.ambiguousEastAsianCharWidth) || 1;
+function stringWidth (ambiguousCharWidth) {
     return function widthOf (str) {
         var i, code, width = 0;
         for(i = 0; i < str.length; i+=1) {
@@ -27,4 +26,5 @@ function stringWidth (config) {
     };
 }
 
-module.exports = stringWidth;
+module.exports = stringWidth(2);
+module.exports.narrow = stringWidth(1);

--- a/packages/power-assert-util-string-width/package.json
+++ b/packages/power-assert-util-string-width/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "power-assert-renderer-diagram",
-  "description": "diagram renderer for power-assert context",
+  "name": "power-assert-util-string-width",
+  "description": "calculates width of given string",
   "version": "1.0.7",
   "author": {
     "name": "Takuto Wada",
@@ -11,23 +11,20 @@
     "url": "https://github.com/twada/power-assert-runtime/issues"
   },
   "dependencies": {
-    "core-js": "^2.0.0",
-    "power-assert-renderer-base": "^1.0.7",
-    "power-assert-util-string-width": "^1.0.7",
-    "stringifier": "^1.3.0"
+    "eastasianwidth": "^0.1.1"
   },
   "devDependencies": {
-    "mocha": "^2.4.5",
-    "power-assert-renderer-assertion": "^1.0.7"
+    "mocha": "^2.4.5"
   },
   "files": [
     "README.md",
-    "index.js",
-    "lib"
+    "index.js"
   ],
   "homepage": "https://github.com/twada/power-assert-runtime",
   "keywords": [
-    "power-assert"
+    "string",
+    "width",
+    "unicode"
   ],
   "license": "MIT",
   "main": "index.js",

--- a/packages/power-assert-util-string-width/test/test.js
+++ b/packages/power-assert-util-string-width/test/test.js
@@ -1,9 +1,8 @@
-delete require.cache[require.resolve('../lib/string-width')];
-var stringWidth = require('../lib/string-width');
+delete require.cache[require.resolve('..')];
+var stringWidth = require('..');
 var assert = require('assert');
 
-describe('string-width', function () {
-    var widthOf = stringWidth();
+describe('stringWidth', function () {
     [
         ['abcde',  5],
         ['あいうえお',  10],
@@ -11,7 +10,7 @@ describe('string-width', function () {
     ].forEach(function(col, idx) {
         var input = col[0], expected = col[1];
         it(idx + ': ' + input, function () {
-            assert.equal(widthOf(input), expected);
+            assert.equal(stringWidth(input), expected);
         });
     });
 
@@ -19,19 +18,19 @@ describe('string-width', function () {
         it('composition', function () {
             var str = 'が';
             assert.equal(str.length, 1);
-            assert.equal(widthOf(str), 2);
+            assert.equal(stringWidth(str), 2);
         });
         it('decomposition', function () {
             var str = 'か\u3099';
             assert.equal(str.length, 2);
-            assert.equal(widthOf(str), 4);
+            assert.equal(stringWidth(str), 4);
         });
     });
 
     it('surrogate pair', function () {
         var strWithSurrogatePair = "𠮷野家で𩸽";
         assert.equal(strWithSurrogatePair.length, 7);
-        assert.equal(widthOf(strWithSurrogatePair), 10);
+        assert.equal(stringWidth(strWithSurrogatePair), 10);
     });
 });
 
@@ -39,16 +38,10 @@ describe('ambiguous EastAsianWidth', function () {
     beforeEach(function () {
         this.strWithAmbiguousEastAsian = '※ただしイケメンに限る';
     });
-    it('when set to 1', function () {
-        var widthOf = stringWidth({
-            ambiguousEastAsianCharWidth: 1
-        });
-        assert.equal(widthOf(this.strWithAmbiguousEastAsian), 21);
+    it('Treat ambiguous-width characters as fullwidth (= `2`) by default.', function () {
+        assert.equal(stringWidth(this.strWithAmbiguousEastAsian), 22);
     });
-    it('when set to 2', function () {
-        var widthOf = stringWidth({
-            ambiguousEastAsianCharWidth: 2
-        });
-        assert.equal(widthOf(this.strWithAmbiguousEastAsian), 22);
+    it('stringWidth.narrow treats ambiguous-width characters as narrow (= `1`)', function () {
+        assert.equal(stringWidth.narrow(this.strWithAmbiguousEastAsian), 21);
     });
 });

--- a/packages/power-assert-util-string-width/test/test.js
+++ b/packages/power-assert-util-string-width/test/test.js
@@ -36,12 +36,12 @@ describe('stringWidth', function () {
 
 describe('ambiguous EastAsianWidth', function () {
     beforeEach(function () {
-        this.strWithAmbiguousEastAsian = '※ただしイケメンに限る';
+        this.strWithAmbiguousEastAsian = '※脚注';
     });
     it('Treat ambiguous-width characters as fullwidth (= `2`) by default.', function () {
-        assert.equal(stringWidth(this.strWithAmbiguousEastAsian), 22);
+        assert.equal(stringWidth(this.strWithAmbiguousEastAsian), 6);
     });
     it('stringWidth.narrow treats ambiguous-width characters as narrow (= `1`)', function () {
-        assert.equal(stringWidth.narrow(this.strWithAmbiguousEastAsian), 21);
+        assert.equal(stringWidth.narrow(this.strWithAmbiguousEastAsian), 5);
     });
 });


### PR DESCRIPTION
```js
var stringWidth = require('power-assert-util-string-width');

stringWidth('abcde'); //=> 5
stringWidth('あいうえお'); //=> 10
stringWidth('ｱｲｳｴｵ'); //=> 5
stringWidth('※脚注');  //=> 6
// stringWidth.narrow treats ambiguous-width characters as narrow (= `1`)
stringWidth.narrow('※脚注');  //=> 5
```
