### PR TITLE
Degrade gracefully when there are some parse errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "babel-preset-react": "^6.1.0",
     "babel-preset-stage-2": "^6.1.0",
     "babel-plugin-transform-function-bind": "^6.1.0",
+    "core-js": "^2.0.0",
     "empower-core": "^0.6.0",
     "lerna": "^1.1.2",
     "mocha": "^2.4.5"

--- a/packages/power-assert-context-formatter/test/test.js
+++ b/packages/power-assert-context-formatter/test/test.js
@@ -157,8 +157,9 @@ describe('power-assert-context-formatter : reducers option', function () {
                 '                        ?                       ',
                 '                        ?                       ',
                 '                        SyntaxError: Unexpected token (1:22)',
-                '                        If you are using `babel-plugin-espower` and want to use experimental syntax in your assert(), you should set `embedAst` option to true.',
-                '                        see: https://github.com/power-assert-js/babel-plugin-espower#optionsembedast',
+                '                                                ',
+                '  If you are using `babel-plugin-espower` and want to use experimental syntax in your assert(), you should set `embedAst` option to true.',
+                '  see: https://github.com/power-assert-js/babel-plugin-espower#optionsembedast',
                 '                                                ',
                 '                                                ',
                 '  '

--- a/packages/power-assert-context-formatter/test/test.js
+++ b/packages/power-assert-context-formatter/test/test.js
@@ -157,6 +157,8 @@ describe('power-assert-context-formatter : reducers option', function () {
                 '                        ?                       ',
                 '                        ?                       ',
                 '                        SyntaxError: Unexpected token (1:22)',
+                '                        If you are using `babel-plugin-espower` and want to use experimental syntax in your assert(), you should set `embedAst` option to true.',
+                '                        see: https://github.com/power-assert-js/babel-plugin-espower#optionsembedast',
                 '                                                ',
                 '                                                ',
                 '  '

--- a/packages/power-assert-context-formatter/test/test.js
+++ b/packages/power-assert-context-formatter/test/test.js
@@ -134,6 +134,36 @@ describe('power-assert-context-formatter : reducers option', function () {
         }
     });
 
+    it('degrade gracefully when there are some parse errors caused by not supported syntax', function () {
+        var format = createFormatter({
+            reducers: [
+                appendAst
+            ],
+            renderers: [
+                AssertionRenderer,
+                DiagramRenderer
+            ]
+        });
+        try {
+            var a = 'a';
+            var b = 'b';
+            var obj = { foo: 'FOO', bar: 'BAR' };
+            eval(transpile('assert.deepEqual({ b, ...obj }, { a, ...obj })', false));
+        } catch (e) {
+            var result = format(e.powerAssertContext);
+            baseAssert.equal(result, [
+                '  ',
+                '  assert.deepEqual({ b, ...obj }, { a, ...obj })',
+                '                        ?                       ',
+                '                        ?                       ',
+                '                        SyntaxError: Unexpected token (1:22)',
+                '                                                ',
+                '                                                ',
+                '  '
+            ].join('\n'));
+        }
+    });
+
 });
 
 

--- a/packages/power-assert-context-reducer-ast/index.js
+++ b/packages/power-assert-context-reducer-ast/index.js
@@ -11,7 +11,12 @@ module.exports = function (powerAssertContext) {
     if (source.ast && source.tokens && source.visitorKeys) {
         return powerAssertContext;
     }
-    var astAndTokens = parse(source);
+    var astAndTokens;
+    try {
+        astAndTokens = parse(source);
+    } catch (e) {
+        return assign({}, powerAssertContext, { source: assign({}, source, { error: e }) });
+    }
     var newSource = assign({}, source, {
         ast: purifyAst(astAndTokens.expression),
         tokens: astAndTokens.tokens,

--- a/packages/power-assert-context-reducer-ast/test/test.js
+++ b/packages/power-assert-context-reducer-ast/test/test.js
@@ -157,4 +157,21 @@ describe('Bug reproduction case', function () {
         };
         assert.deepEqual(actual, expected);
     });
+
+
+    it('degrade gracefully when there are some parse errors caused by not supported syntax', function () {
+        var input = {
+            source: {
+                content: 'assert(shallow(<Foo />).contains(<div className="foo" />));',
+                filepath: 'test/some_test.js',
+                line: 1
+            },
+            args: [
+            ]
+        };
+        var actual = reduce(input);
+        assert(actual.source.error);
+        assert(actual.source.error instanceof SyntaxError);
+    });
+
 });

--- a/packages/power-assert-renderer-assertion/index.js
+++ b/packages/power-assert-renderer-assertion/index.js
@@ -26,8 +26,9 @@ AssertionRenderer.prototype.onEnd = function () {
             this.renderValueAt(syntaxErrorIndex, '?');
             this.renderValueAt(syntaxErrorIndex, '?');
             this.renderValueAt(syntaxErrorIndex, e.toString());
-            this.renderValueAt(syntaxErrorIndex, 'If you are using `babel-plugin-espower` and want to use experimental syntax in your assert(), you should set `embedAst` option to true.');
-            this.renderValueAt(syntaxErrorIndex, 'see: https://github.com/power-assert-js/babel-plugin-espower#optionsembedast');
+            this.renderValueAt(0, '');
+            this.renderValueAt(0, 'If you are using `babel-plugin-espower` and want to use experimental syntax in your assert(), you should set `embedAst` option to true.');
+            this.renderValueAt(0, 'see: https://github.com/power-assert-js/babel-plugin-espower#optionsembedast');
         }
     }
 };

--- a/packages/power-assert-renderer-assertion/index.js
+++ b/packages/power-assert-renderer-assertion/index.js
@@ -26,6 +26,8 @@ AssertionRenderer.prototype.onEnd = function () {
             this.renderValueAt(syntaxErrorIndex, '?');
             this.renderValueAt(syntaxErrorIndex, '?');
             this.renderValueAt(syntaxErrorIndex, e.toString());
+            this.renderValueAt(syntaxErrorIndex, 'If you are using `babel-plugin-espower` and want to use experimental syntax in your assert(), you should set `embedAst` option to true.');
+            this.renderValueAt(syntaxErrorIndex, 'see: https://github.com/power-assert-js/babel-plugin-espower#optionsembedast');
         }
     }
 };

--- a/packages/power-assert-renderer-assertion/index.js
+++ b/packages/power-assert-renderer-assertion/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var BaseRenderer = require('power-assert-renderer-base');
+var stringWidth = require('power-assert-util-string-width');
 var inherits = require('util').inherits;
 
 function AssertionRenderer () {
@@ -9,12 +10,45 @@ function AssertionRenderer () {
 inherits(AssertionRenderer, BaseRenderer);
 
 AssertionRenderer.prototype.onStart = function (context) {
+    this.context = context;
     this.assertionLine = context.source.content;
 };
 
 AssertionRenderer.prototype.onEnd = function () {
     this.write('');
     this.write(this.assertionLine);
+    var e = this.context.source.error;
+    if (e && e instanceof SyntaxError) {
+        var re = /Unexpected token \(1\:(\d+)\)/;
+        var matchResult = re.exec(e.message);
+        if (matchResult) {
+            var syntaxErrorIndex = Number(matchResult[1]);
+            this.renderValueAt(syntaxErrorIndex, '?');
+            this.renderValueAt(syntaxErrorIndex, '?');
+            this.renderValueAt(syntaxErrorIndex, e.toString());
+        }
+    }
 };
+
+AssertionRenderer.prototype.renderValueAt = function (idx, str) {
+    var row = createRow(stringWidth(this.assertionLine), ' ');
+    replaceColumn(idx, row, str);
+    this.write(row.join(''));
+};
+
+function replaceColumn (columnIndex, row, str) {
+    var i, width = stringWidth(str);
+    for (i = 0; i < width; i += 1) {
+        row.splice(columnIndex + i, 1, str.charAt(i));
+    }
+}
+
+function createRow (numCols, initial) {
+    var row = [], i;
+    for(i = 0; i < numCols; i += 1) {
+        row[i] = initial;
+    }
+    return row;
+}
 
 module.exports = AssertionRenderer;

--- a/packages/power-assert-renderer-assertion/package.json
+++ b/packages/power-assert-renderer-assertion/package.json
@@ -11,10 +11,12 @@
     "url": "https://github.com/twada/power-assert-runtime/issues"
   },
   "dependencies": {
-    "power-assert-renderer-base": "^1.0.7"
+    "power-assert-renderer-base": "^1.0.7",
+    "power-assert-util-string-width": "^1.0.7"
   },
   "devDependencies": {
-    "mocha": "^2.4.5"
+    "mocha": "^2.4.5",
+    "power-assert-context-reducer-ast": "^1.0.7"
   },
   "files": [
     "README.md",

--- a/packages/power-assert-renderer-assertion/test/test.js
+++ b/packages/power-assert-renderer-assertion/test/test.js
@@ -5,8 +5,10 @@ var AssertionRenderer = require('..');
 var assert = require('../../../test_helper/empowered-assert');
 var transpile = require('../../../test_helper/transpile');
 var testRendering = require('../../../test_helper/test-rendering');
+var appendAst = require('power-assert-context-reducer-ast');
 
 describe('AssertionRenderer', function () {
+
     it('assert(foo === bar)', function () {
         var foo = 'foo';
         var bar = 'bar';
@@ -15,6 +17,27 @@ describe('AssertionRenderer', function () {
         }, [
             '',
             'assert(foo === bar)'
-        ], [AssertionRenderer]);
+        ], { renderers: [AssertionRenderer] });
     });
+
+    it('show syntax error when there are some parse errors caused by not supported syntax', function () {
+        var a = 'a';
+        var b = 'b';
+        var obj = { foo: 'FOO', bar: 'BAR' };
+        testRendering(function () {
+            eval(transpile('assert.deepEqual({ b, ...obj }, { a, ...obj })', false));
+        }, [
+            '',
+            'assert.deepEqual({ b, ...obj }, { a, ...obj })',
+            '                      ?                       ',
+            '                      ?                       ',
+            '                      SyntaxError: Unexpected token (1:22)'
+        ], {
+            reducers: [
+                appendAst
+            ],
+            renderers: [AssertionRenderer]
+        });
+    });
+
 });

--- a/packages/power-assert-renderer-assertion/test/test.js
+++ b/packages/power-assert-renderer-assertion/test/test.js
@@ -32,8 +32,9 @@ describe('AssertionRenderer', function () {
             '                      ?                       ',
             '                      ?                       ',
             '                      SyntaxError: Unexpected token (1:22)',
-            '                      If you are using `babel-plugin-espower` and want to use experimental syntax in your assert(), you should set `embedAst` option to true.',
-            '                      see: https://github.com/power-assert-js/babel-plugin-espower#optionsembedast'
+            '                                              ',
+            'If you are using `babel-plugin-espower` and want to use experimental syntax in your assert(), you should set `embedAst` option to true.',
+            'see: https://github.com/power-assert-js/babel-plugin-espower#optionsembedast'
         ], {
             reducers: [
                 appendAst

--- a/packages/power-assert-renderer-assertion/test/test.js
+++ b/packages/power-assert-renderer-assertion/test/test.js
@@ -31,7 +31,9 @@ describe('AssertionRenderer', function () {
             'assert.deepEqual({ b, ...obj }, { a, ...obj })',
             '                      ?                       ',
             '                      ?                       ',
-            '                      SyntaxError: Unexpected token (1:22)'
+            '                      SyntaxError: Unexpected token (1:22)',
+            '                      If you are using `babel-plugin-espower` and want to use experimental syntax in your assert(), you should set `embedAst` option to true.',
+            '                      see: https://github.com/power-assert-js/babel-plugin-espower#optionsembedast'
         ], {
             reducers: [
                 appendAst

--- a/packages/power-assert-renderer-file/test/test.js
+++ b/packages/power-assert-renderer-file/test/test.js
@@ -15,7 +15,7 @@ describe('FileRenderer', function () {
             eval(transpile('assert(foo === bar)'));
         }, [
             '# test/some_test.js:1'
-        ], [FileRenderer]);
+        ], { renderers: [FileRenderer] });
     });
 
     it('line number detection', function () {
@@ -24,7 +24,7 @@ describe('FileRenderer', function () {
             eval(transpile('var i = 0;\n\nassert(falsyStr)'));
         }, [
             '# test/some_test.js:3'
-        ], [FileRenderer]);
+        ], { renderers: [FileRenderer] });
     });
 
 });

--- a/test_helper/create-renderer-tester.js
+++ b/test_helper/create-renderer-tester.js
@@ -10,7 +10,9 @@ module.exports = function createRendererTester (renderer) {
         it(title + ': ' + expression, function () {
             testRendering(function () {
                 body(transpile(expression));
-            }, [''].concat(expectedLines), [AssertionRenderer, renderer]);
+            }, [''].concat(expectedLines), {
+                renderers: [AssertionRenderer, renderer]
+            });
         });
     };
 }

--- a/test_helper/test-rendering.js
+++ b/test_helper/test-rendering.js
@@ -2,17 +2,17 @@
 
 var createFormatter = require('../packages/power-assert-context-formatter');
 var baseAssert = require('assert');
+var assign = require('core-js/library/fn/object/assign');
 
-module.exports = function testRendering (body, expectedLines, renderers) {
+module.exports = function testRendering (body, expectedLines, formatterOptions) {
     try {
         body();
         baseAssert.fail('AssertionError should be thrown');
     } catch (e) {
         baseAssert.equal(typeof e.powerAssertContext, 'object', 'powerAssertContext should exist');
-        var format = createFormatter({
-            outputOffset: 0,
-            renderers: renderers
-        });
+        var format = createFormatter(assign({}, {
+            outputOffset: 0
+        }, formatterOptions));
         baseAssert.equal(format(e.powerAssertContext), expectedLines.join('\n') + '\n');
     }
 };


### PR DESCRIPTION
Instead of hard error, show syntax error when there are some parse errors caused by not-supported syntax.


example:
```
  assert.deepEqual({ b, ...obj }, { a, ...obj })
                        ?                       
                        ?                       
                        SyntaxError: Unexpected token (1:22)
  
  If you are using `babel-plugin-espower` and want to use experimental syntax in your assert(), you should set `embedAst` option to true.
  see: https://github.com/power-assert-js/babel-plugin-espower#optionsembedast
```
