### PR TITLE
fix: support async function

### DIFF
--- a/packages/power-assert-context-reducer-ast/index.js
+++ b/packages/power-assert-context-reducer-ast/index.js
@@ -28,7 +28,7 @@ module.exports = function (powerAssertContext) {
 function parserOptions(tokens) {
     return {
         sourceType: 'module',
-        ecmaVersion: 7,
+        ecmaVersion: 2017,
         locations: true,
         ranges: false,
         onToken: tokens,

--- a/packages/power-assert-context-reducer-ast/test/test.js
+++ b/packages/power-assert-context-reducer-ast/test/test.js
@@ -174,4 +174,27 @@ describe('Bug reproduction case', function () {
         assert(actual.source.error instanceof SyntaxError);
     });
 
+    it('support async function', function () {
+        var input = {
+            source: {
+                async: true,
+                content: 'assert(await a === await b)',
+                filepath: 'test/some_test.js',
+            },
+            args: []
+        };
+        var actual = reduce(input);
+        var expected = {
+            source: {
+              async: true,
+              content: 'assert(await a === await b)',
+              filepath: 'test/some_test.js',
+              ast: JSON.parse('{"type":"CallExpression","callee":{"type":"Identifier","name":"assert","range":[0,6]},"arguments":[{"type":"BinaryExpression","operator":"===","left":{"type":"AwaitExpression","argument":{"type":"Identifier","name":"a","range":[13,14]},"range":[7,14]},"right":{"type":"AwaitExpression","argument":{"type":"Identifier","name":"b","range":[25,26]},"range":[19,26]},"range":[7,26]}],"range":[0,27]}'),
+              tokens: JSON.parse('[{"type":{"label":"name"},"value":"assert","range":[0,6]},{"type":{"label":"("},"range":[6,7]},{"type":{"label":"name"},"value":"await","range":[7,12]},{"type":{"label":"name"},"value":"a","range":[13,14]},{"type":{"label":"==/!="},"value":"===","range":[15,18]},{"type":{"label":"name"},"value":"await","range":[19,24]},{"type":{"label":"name"},"value":"b","range":[25,26]},{"type":{"label":")"},"range":[26,27]}]'),
+              visitorKeys: estraverse.VisitorKeys
+            },
+            args: []
+        };
+        assert.deepEqual(actual, expected);
+    });
 });


### PR DESCRIPTION
It will parse error with acorn when I use async function in testcase

```
it('test include async function', async () => {
  const a = 1;
  const b = 2;
  assert(a === b);
});
```

The result is not expected.

```
  assert(a === b)
        ?        
        ?        
        SyntaxError: Unexpected token (1:6)
```