### PR TITLE
feat: support ES2018 syntax

### DIFF
--- a/packages/power-assert-context-formatter/test/test.js
+++ b/packages/power-assert-context-formatter/test/test.js
@@ -144,24 +144,28 @@ describe('power-assert-context-formatter : reducers option', function () {
                 DiagramRenderer
             ]
         });
+        function validate(name) {
+            return {
+                name: name,
+                valid: true,
+                value: this
+            };
+        }
         try {
-            var a = 'a';
-            var b = 'b';
-            var obj = { foo: 'FOO', bar: 'BAR' };
-            eval(transpile('assert.deepEqual({ b, ...obj }, { a, ...obj })', false));
+            eval(transpile('assert.deepEqual(true::validate("foo"), { valid: true, value: true, name: "bar" })', false));
         } catch (e) {
             var result = format(e.powerAssertContext);
             baseAssert.equal(result, [
                 '  ',
-                '  assert.deepEqual({ b, ...obj }, { a, ...obj })',
-                '                        ?                       ',
-                '                        ?                       ',
-                '                        SyntaxError: Unexpected token (1:22)',
-                '                                                ',
+                '  assert.deepEqual(true::validate("foo"), { valid: true, value: true, name: "bar" })',
+                '                       ?                                                            ',
+                '                       ?                                                            ',
+                '                       SyntaxError: Unexpected token (1:21)                         ',
+                '                                                                                    ',
                 '  If you are using `babel-plugin-espower` and want to use experimental syntax in your assert(), you should set `embedAst` option to true.',
-                '  see: https://github.com/power-assert-js/babel-plugin-espower#optionsembedast',
-                '                                                ',
-                '                                                ',
+                '  see: https://github.com/power-assert-js/babel-plugin-espower#optionsembedast      ',
+                '                                                                                    ',
+                '                                                                                    ',
                 '  '
             ].join('\n'));
         }

--- a/packages/power-assert-context-reducer-ast/index.js
+++ b/packages/power-assert-context-reducer-ast/index.js
@@ -28,7 +28,7 @@ module.exports = function (powerAssertContext) {
 function parserOptions(tokens) {
     return {
         sourceType: 'module',
-        ecmaVersion: 2017,
+        ecmaVersion: 2018,
         locations: true,
         ranges: false,
         onToken: tokens,

--- a/packages/power-assert-context-reducer-ast/package.json
+++ b/packages/power-assert-context-reducer-ast/package.json
@@ -17,7 +17,7 @@
     }
   ],
   "dependencies": {
-    "acorn": "^4.0.0",
+    "acorn": "^5.0.0",
     "acorn-es7-plugin": "^1.0.12",
     "core-js": "^2.0.0",
     "espurify": "^1.6.0",

--- a/packages/power-assert-context-reducer-ast/test/test.js
+++ b/packages/power-assert-context-reducer-ast/test/test.js
@@ -65,7 +65,7 @@ describe('power-assert-context-reducer-ast', function () {
                 filepath: 'test/some_test.js',
                 line: 1,
                 ast: JSON.parse('{"type":"CallExpression","callee":{"type":"Identifier","name":"assert","range":[0,6]},"arguments":[{"type":"BinaryExpression","operator":"===","left":{"type":"Identifier","name":"foo","range":[7,10]},"right":{"type":"Identifier","name":"bar","range":[15,18]},"range":[7,18]}],"range":[0,19]}'),
-                tokens: JSON.parse('[{"type":{"label":"name"},"value":"assert","range":[0,6]},{"type":{"label":"("},"range":[6,7]},{"type":{"label":"name"},"value":"foo","range":[7,10]},{"type":{"label":"==/!="},"value":"===","range":[11,14]},{"type":{"label":"name"},"value":"bar","range":[15,18]},{"type":{"label":")"},"range":[18,19]}]'),
+                tokens: JSON.parse('[{"type":{"label":"name"},"value":"assert","range":[0,6]},{"type":{"label":"("},"range":[6,7]},{"type":{"label":"name"},"value":"foo","range":[7,10]},{"type":{"label":"==/!=/===/!=="},"value":"===","range":[11,14]},{"type":{"label":"name"},"value":"bar","range":[15,18]},{"type":{"label":")"},"range":[18,19]}]'),
                 visitorKeys: estraverse.VisitorKeys
             },
             args: [
@@ -99,7 +99,7 @@ describe('power-assert-context-reducer-ast', function () {
                 filepath: 'test/some_test.js',
                 line: 1,
                 ast: '{"type":"CallExpression","callee":{"type":"Identifier","name":"assert","range":[0,6]},"arguments":[{"type":"BinaryExpression","operator":"===","left":{"type":"Identifier","name":"foo","range":[7,10]},"right":{"type":"Identifier","name":"bar","range":[15,18]},"range":[7,18]}],"range":[0,19]}',
-                tokens: '[{"type":{"label":"name"},"value":"assert","range":[0,6]},{"type":{"label":"("},"range":[6,7]},{"type":{"label":"name"},"value":"foo","range":[7,10]},{"type":{"label":"==/!="},"value":"===","range":[11,14]},{"type":{"label":"name"},"value":"bar","range":[15,18]},{"type":{"label":")"},"range":[18,19]}]',
+                tokens: '[{"type":{"label":"name"},"value":"assert","range":[0,6]},{"type":{"label":"("},"range":[6,7]},{"type":{"label":"name"},"value":"foo","range":[7,10]},{"type":{"label":"==/!=/===/!=="},"value":"===","range":[11,14]},{"type":{"label":"name"},"value":"bar","range":[15,18]},{"type":{"label":")"},"range":[18,19]}]',
                 visitorKeys: JSON.stringify(estraverse.VisitorKeys)
             },
             args: [
@@ -190,7 +190,7 @@ describe('Bug reproduction case', function () {
               content: 'assert(await a === await b)',
               filepath: 'test/some_test.js',
               ast: JSON.parse('{"type":"CallExpression","callee":{"type":"Identifier","name":"assert","range":[0,6]},"arguments":[{"type":"BinaryExpression","operator":"===","left":{"type":"AwaitExpression","argument":{"type":"Identifier","name":"a","range":[13,14]},"range":[7,14]},"right":{"type":"AwaitExpression","argument":{"type":"Identifier","name":"b","range":[25,26]},"range":[19,26]},"range":[7,26]}],"range":[0,27]}'),
-              tokens: JSON.parse('[{"type":{"label":"name"},"value":"assert","range":[0,6]},{"type":{"label":"("},"range":[6,7]},{"type":{"label":"name"},"value":"await","range":[7,12]},{"type":{"label":"name"},"value":"a","range":[13,14]},{"type":{"label":"==/!="},"value":"===","range":[15,18]},{"type":{"label":"name"},"value":"await","range":[19,24]},{"type":{"label":"name"},"value":"b","range":[25,26]},{"type":{"label":")"},"range":[26,27]}]'),
+              tokens: JSON.parse('[{"type":{"label":"name"},"value":"assert","range":[0,6]},{"type":{"label":"("},"range":[6,7]},{"type":{"label":"name"},"value":"await","range":[7,12]},{"type":{"label":"name"},"value":"a","range":[13,14]},{"type":{"label":"==/!=/===/!=="},"value":"===","range":[15,18]},{"type":{"label":"name"},"value":"await","range":[19,24]},{"type":{"label":"name"},"value":"b","range":[25,26]},{"type":{"label":")"},"range":[26,27]}]'),
               visitorKeys: estraverse.VisitorKeys
             },
             args: []

--- a/packages/power-assert-renderer-assertion/test/test.js
+++ b/packages/power-assert-renderer-assertion/test/test.js
@@ -21,20 +21,24 @@ describe('AssertionRenderer', function () {
     });
 
     it('show syntax error when there are some parse errors caused by not supported syntax', function () {
-        var a = 'a';
-        var b = 'b';
-        var obj = { foo: 'FOO', bar: 'BAR' };
+        function validate(name) {
+            return {
+                name: name,
+                valid: true,
+                value: this
+            };
+        }
         testRendering(function () {
-            eval(transpile('assert.deepEqual({ b, ...obj }, { a, ...obj })', false));
+            eval(transpile('assert.deepEqual(true::validate("foo"), { valid: true, value: true, name: "bar" })', false));
         }, [
             '',
-            'assert.deepEqual({ b, ...obj }, { a, ...obj })',
-            '                      ?                       ',
-            '                      ?                       ',
-            '                      SyntaxError: Unexpected token (1:22)',
-            '                                              ',
+            'assert.deepEqual(true::validate("foo"), { valid: true, value: true, name: "bar" })',
+            '                     ?                                                            ',
+            '                     ?                                                            ',
+            '                     SyntaxError: Unexpected token (1:21)                         ',
+            '                                                                                  ',
             'If you are using `babel-plugin-espower` and want to use experimental syntax in your assert(), you should set `embedAst` option to true.',
-            'see: https://github.com/power-assert-js/babel-plugin-espower#optionsembedast'
+            'see: https://github.com/power-assert-js/babel-plugin-espower#optionsembedast      '
         ], {
             reducers: [
                 appendAst


### PR DESCRIPTION
Update runtime side parser (acorn) and set `ecmaVersion: 2018` to support ES2018 syntax